### PR TITLE
Add two boolean flag to prevent expand or collapse pass through anchored state.

### DIFF
--- a/library/src/main/java/com/trafi/anchorbottomsheetbehavior/AnchorBottomSheetBehavior.java
+++ b/library/src/main/java/com/trafi/anchorbottomsheetbehavior/AnchorBottomSheetBehavior.java
@@ -200,6 +200,9 @@ public class AnchorBottomSheetBehavior<V extends View> extends CoordinatorLayout
 
     boolean mTouchingScrollingChild;
 
+    private boolean mShouldAnchoredBeforeExpand = false;
+    private boolean mShouldAnchoredBeforeCollapse = false;
+
     /**
      * Default constructor for instantiating AnchorBottomSheetBehaviors.
      */
@@ -232,6 +235,9 @@ public class AnchorBottomSheetBehavior<V extends View> extends CoordinatorLayout
         mAnchorOffset = (int) a.getDimension(R.styleable.AnchorBottomSheetBehavior_Layout_behavior_anchorOffset, 0);
         //noinspection WrongConstant
         mState = a.getInt(R.styleable.AnchorBottomSheetBehavior_Layout_behavior_defaultState, mState);
+
+        mShouldAnchoredBeforeExpand = a.getBoolean(R.styleable.AnchorBottomSheetBehavior_Layout_behavior_shouldAnchoredBeforeExpand, false);
+        mShouldAnchoredBeforeCollapse = a.getBoolean(R.styleable.AnchorBottomSheetBehavior_Layout_behavior_shouldAnchoredBeforeCollapse, false);
         a.recycle();
 
         ViewConfiguration configuration = ViewConfiguration.get(context);
@@ -741,7 +747,10 @@ public class AnchorBottomSheetBehavior<V extends View> extends CoordinatorLayout
         int currentTop = child.getTop();
         if (currentTop < mAnchorOffset) {
             return true;
+        } else if (mShouldAnchoredBeforeExpand) {
+            return false;
         }
+
         final float newTop = currentTop + yvel * EXPAND_FRICTION;
         return newTop < mAnchorOffset;
     }
@@ -750,7 +759,10 @@ public class AnchorBottomSheetBehavior<V extends View> extends CoordinatorLayout
         int currentTop = child.getTop();
         if (currentTop > mAnchorOffset) {
             return true;
+        } else if (mShouldAnchoredBeforeCollapse) {
+            return false;
         }
+
         final float newTop = currentTop + yvel * COLLAPSE_FRICTION;
         return newTop > mAnchorOffset;
     }

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -8,5 +8,8 @@
             <enum name="hidden" value="5" />
             <enum name="anchored" value="6" />
         </attr>
+
+        <attr name="behavior_shouldAnchoredBeforeExpand" format="boolean" />
+        <attr name="behavior_shouldAnchoredBeforeCollapse" format="boolean" />
     </declare-styleable>
 </resources>

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -57,6 +57,8 @@
         app:behavior_anchorOffset="@dimen/anchor_offset"
         app:behavior_peekHeight="@dimen/peek_height"
         app:behavior_defaultState="collapsed"
+        app:behavior_shouldAnchoredBeforeExpand="false"
+        app:behavior_shouldAnchoredBeforeCollapse="false"
         app:layout_behavior="com.trafi.anchorbottomsheetbehavior.AnchorBottomSheetBehavior">
 
         <TextView


### PR DESCRIPTION
### Preview
| State        | Image           | 
| ------------- |:-------------:| 
| normal usage      |  ![demo01](https://user-images.githubusercontent.com/4803452/42617300-cb91932a-85e3-11e8-8e91-13c66c565fee.gif) | 
| shouldAnchoredBeforeExpand     |  ![demo02](https://user-images.githubusercontent.com/4803452/42617348-f54fe1d0-85e3-11e8-87a7-9c68c2054561.gif)      |
| shouldAnchoredBeforeCollapse     | ![demo03](https://user-images.githubusercontent.com/4803452/42617419-2c0b4458-85e4-11e8-90a4-c9139cd753ae.gif)      | 
| enable both flags      | ![demo04](https://user-images.githubusercontent.com/4803452/42617439-38cf5bac-85e4-11e8-8742-fb26f5d18f8f.gif)      |






### Description
In the current version, it is too easy to bypass the anchor level height (It will act like normal bottom sheet behavior).
If there have an intermediate page, it's not easy to scroll in anchor height and make the position locked.
Sometimes, It causes bad user experience.

This problem is caused by the method of shouldExpand and shouldCollapsed.
When the bottom sheet is below the anchor height, the 'shouldExpand' method will return
the value, which depends on the new top value(calculated by the current bottom sheet height and
user's scrolling velocity multiply the friction const value)
large then the anchor height, and make the bottom sheet expand,
so as the 'shouldCollapsed' method.

I add two boolean flags to prevent the behavior above.
Take the 'shouldExpand' for example, if the bottom sheet is above the anchor height but it's not in the anchor state.
It should scroll to anchor level first.
When it comes to collapsing situation, The bottom sheet should collapse from expanded state to anchor height then collapsed state.

### Usage
```xml
    <LinearLayout
        android:id="@+id/bottom_sheet"
        android:layout_width="match_parent"
        android:layout_height="wrap_content"
        app:behavior_shouldAnchoredBeforeExpand="true or false"
        app:behavior_shouldAnchoredBeforeCollapse="true of false"
        app:layout_behavior="com.trafi.anchorbottomsheetbehavior.AnchorBottomSheetBehavior"
        />
```