### PR TITLE
Accommodate short sheet content

### DIFF
--- a/library/src/main/java/com/trafi/anchorbottomsheetbehavior/AnchorBottomSheetBehavior.java
+++ b/library/src/main/java/com/trafi/anchorbottomsheetbehavior/AnchorBottomSheetBehavior.java
@@ -754,22 +754,20 @@ public class AnchorBottomSheetBehavior<V extends View> extends CoordinatorLayout
         } else {
             // not scrolling much, i.e. stationary
             int currentTop = child.getTop();
-            if (currentTop < mAnchorOffset) {
-                if (Math.abs(currentTop - mMinOffset) < Math.abs(currentTop - mAnchorOffset)) {
-                    top = mMinOffset;
-                    targetState = STATE_EXPANDED;
-                } else {
-                    top = Math.max(mMinOffset, mAnchorOffset);
-                    targetState = STATE_ANCHORED;
-                }
+            int distanceToExpanded = Math.abs(currentTop - mMinOffset);
+            int distanceToCollapsed = Math.abs(currentTop - mMaxOffset);
+            int distanceToAnchor = Math.abs(currentTop - mAnchorOffset);
+            if (mAnchorOffset > mMinOffset
+                    && distanceToAnchor < distanceToExpanded
+                    && distanceToAnchor < distanceToCollapsed) {
+                top = mAnchorOffset;
+                targetState = STATE_ANCHORED;
+            } else if (distanceToExpanded < distanceToCollapsed) {
+                top = mMinOffset;
+                targetState = STATE_EXPANDED;
             } else {
-                if (Math.abs(currentTop - mMaxOffset) < Math.abs(currentTop - mAnchorOffset)) {
-                    top = mMaxOffset;
-                    targetState = STATE_COLLAPSED;
-                } else {
-                    top = Math.max(mMinOffset, mAnchorOffset);
-                    targetState = STATE_ANCHORED;
-                }
+                top = mMaxOffset;
+                targetState = STATE_COLLAPSED;
             }
         }
 

--- a/library/src/main/java/com/trafi/anchorbottomsheetbehavior/AnchorBottomSheetBehavior.java
+++ b/library/src/main/java/com/trafi/anchorbottomsheetbehavior/AnchorBottomSheetBehavior.java
@@ -304,7 +304,12 @@ public class AnchorBottomSheetBehavior<V extends View> extends CoordinatorLayout
         } else if (mState == STATE_DRAGGING || mState == STATE_SETTLING) {
             ViewCompat.offsetTopAndBottom(child, savedTop - child.getTop());
         } else if (mState == STATE_ANCHORED) {
-            ViewCompat.offsetTopAndBottom(child, mAnchorOffset);
+            if (mAnchorOffset > mMinOffset) {
+                ViewCompat.offsetTopAndBottom(child, mAnchorOffset);
+            } else {
+                mState = STATE_EXPANDED;
+                ViewCompat.offsetTopAndBottom(child, mMinOffset);
+            }
         }
         if (mViewDragHelper == null) {
             mViewDragHelper = ViewDragHelper.create(parent, mDragCallback);
@@ -754,7 +759,7 @@ public class AnchorBottomSheetBehavior<V extends View> extends CoordinatorLayout
                     top = mMinOffset;
                     targetState = STATE_EXPANDED;
                 } else {
-                    top = mAnchorOffset;
+                    top = Math.max(mMinOffset, mAnchorOffset);
                     targetState = STATE_ANCHORED;
                 }
             } else {
@@ -762,7 +767,7 @@ public class AnchorBottomSheetBehavior<V extends View> extends CoordinatorLayout
                     top = mMaxOffset;
                     targetState = STATE_COLLAPSED;
                 } else {
-                    top = mAnchorOffset;
+                    top = Math.max(mMinOffset, mAnchorOffset);
                     targetState = STATE_ANCHORED;
                 }
             }
@@ -785,7 +790,7 @@ public class AnchorBottomSheetBehavior<V extends View> extends CoordinatorLayout
     }
 
     boolean shouldExpand(View child, float yvel) {
-        if (mSkipAnchored) {
+        if (mSkipAnchored || mMinOffset >= mAnchorOffset) {
             return true;
         }
         int currentTop = child.getTop();
@@ -797,7 +802,7 @@ public class AnchorBottomSheetBehavior<V extends View> extends CoordinatorLayout
     }
 
     boolean shouldCollapse(View child, float yvel) {
-        if (mSkipAnchored) {
+        if (mSkipAnchored || mMinOffset >= mAnchorOffset) {
             return true;
         }
         int currentTop = child.getTop();
@@ -838,7 +843,12 @@ public class AnchorBottomSheetBehavior<V extends View> extends CoordinatorLayout
         } else if (state == STATE_EXPANDED) {
             top = mMinOffset;
         } else if (state == STATE_ANCHORED) {
-            top = mAnchorOffset;
+            if (mAnchorOffset > mMinOffset) {
+                top = mAnchorOffset;
+            } else {
+                state = STATE_EXPANDED;
+                top = mMinOffset;
+            }
         } else if (mHideable && state == STATE_HIDDEN) {
             top = mParentHeight;
         } else {


### PR DESCRIPTION
Previously content that was shorter than the anchor point would cause issues as demonstrated in #6.

We fix this by detecting the case where `mAnchorOffset <= mMinOffset` and skipping directly to the expanded state in such situations. We do not collapse the anchored and expanded states.

Fixes #6 

cc @sregg @eligijusTrafi 